### PR TITLE
Fix testdata for RuleErrorKey5 and RuleContent5

### DIFF
--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -296,14 +296,14 @@ var (
 			PythonModule: string(Rule5.Module),
 		},
 		ErrorKeys: map[string]types.RuleErrorKeyContent{
-			ErrorKey4: {
+			ErrorKey5: {
 				Generic: RuleErrorKey5.Generic,
 				Metadata: types.ErrorKeyMetadata{
 					Condition:   RuleErrorKey5.Condition,
 					Description: RuleErrorKey5.Description,
 					Impact:      ImpactIntToStr[RuleErrorKey5.Impact],
 					Likelihood:  RuleErrorKey5.Likelihood,
-					PublishDate: "2019-10-29 15:00:00",
+					PublishDate: timeToStr(RuleErrorKey5.PublishDate),
 					Status:      statusToStr(RuleErrorKey5.Active),
 					Tags:        RuleErrorKey5.Tags,
 				},


### PR DESCRIPTION
# Description

The rule content present in `testdata` package for the rule content 5 is not 100% correct, so it makes the Smart Proxy unit tests to return a false positive.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Regular CI (if any)