### PR TITLE
Messages with wrong org_id attribute in order to be able to test external data pipeline

### DIFF
--- a/messages/invalid_wrong_org_id/05_rules_hits.json
+++ b/messages/invalid_wrong_org_id/05_rules_hits.json
@@ -1,0 +1,234 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 10,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767aa",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "component": "ccx_rules_ocp.external.rules.nodes_requirements_check.report",
+                "type": "rule",
+                "key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "details": {
+                    "nodes": [
+                        {
+                            "name": "foo1",
+                            "role": "master",
+                            "memory": 8.16,
+                            "memory_req": 16
+                        }
+                    ],
+                    "link": "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal",
+                    "type": "rule",
+                    "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET"
+                },
+                "tags": [],
+                "links": {
+                    "docs": [
+                        "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal"
+                    ]
+                }
+            },
+            {
+                "rule_id": "bug_1766907|BUGZILLA_BUG_1766907",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1766907.report",
+                "type": "rule",
+                "key": "BUGZILLA_BUG_1766907",
+                "details": {
+                    "type": "rule",
+                    "error_key": "BUGZILLA_BUG_1766907"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4631541"
+                    ],
+                    "doc": [],
+                    "bz": [
+                        "https://bugzilla.redhat.com/show_bug.cgi?id=1766907"
+                    ]
+                }
+            },
+            {
+                "rule_id": "nodes_kubelet_version_check|NODE_KUBELET_VERSION",
+                "component": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report",
+                "type": "rule",
+                "key": "NODE_KUBELET_VERSION",
+                "details": {
+                    "nodes_with_different_version": [
+                        {
+                            "Node": "oc1",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc2",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc3",
+                            "Kubelet Version": "v1.14.6+d39ad8449",
+                            "role": "worker"
+                        }
+                    ],
+                    "kcs_link": "https://access.redhat.com/solutions/4602641",
+                    "type": "rule",
+                    "error_key": "NODE_KUBELET_VERSION"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4602641"
+                    ]
+                }
+            },
+            {
+                "rule_id": "samples_op_failed_image_import_check|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "component": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report",
+                "type": "rule",
+                "key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "details": {
+                    "info": {
+                        "name": "openshift-samples",
+                        "condition": "Degraded",
+                        "reason": "FailedImageImports",
+                        "message": "Samples installed at 4.2.0, with image import failures for these imagestreams: php ",
+                        "lastTransitionTime": "2020-03-19T08:32:53Z"
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4563171",
+                    "type": "rule",
+                    "error_key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4563171"
+                    ]
+                }
+            },
+            {
+                "rule_id": "cluster_wide_proxy_auth_check|AUTH_OPERATOR_PROXY_ERROR",
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "type": "rule",
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "details": {
+                    "op": {
+                        "available": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "degraded": {
+                            "message": "WellKnownEndpointDegraded: failed to GET well-known https://10.237.112.145:6443/.well-known/oauth-authorization-server: Tunnel or SSL Forbidden",
+                            "reason": "WellKnownEndpointDegradedError",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:42:33Z"
+                        },
+                        "name": "authentication",
+                        "progressing": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "upgradeable": {
+                            "message": null,
+                            "reason": "AsExpected",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "version": null
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4569191",
+                    "type": "rule",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4569191"
+                    ]
+                }
+            }
+        ],
+        "fingerprints": [],
+        "skips": [
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_ocs_version.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_pods_scc.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PodsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.operator_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.pvc_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.get_mon_reporting_clock_skew'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1801300.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1802248.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_no_access.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_low_capacity.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_no_volume_set_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodEmptyDirVolume', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodPersistentVolume'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_not_bound.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            }
+        ],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/05_rules_hits_org_1.json
+++ b/messages/invalid_wrong_org_id/05_rules_hits_org_1.json
@@ -1,0 +1,234 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 1,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767aa",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "component": "ccx_rules_ocp.external.rules.nodes_requirements_check.report",
+                "type": "rule",
+                "key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "details": {
+                    "nodes": [
+                        {
+                            "name": "foo1",
+                            "role": "master",
+                            "memory": 8.16,
+                            "memory_req": 16
+                        }
+                    ],
+                    "link": "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal",
+                    "type": "rule",
+                    "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET"
+                },
+                "tags": [],
+                "links": {
+                    "docs": [
+                        "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal"
+                    ]
+                }
+            },
+            {
+                "rule_id": "bug_1766907|BUGZILLA_BUG_1766907",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1766907.report",
+                "type": "rule",
+                "key": "BUGZILLA_BUG_1766907",
+                "details": {
+                    "type": "rule",
+                    "error_key": "BUGZILLA_BUG_1766907"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4631541"
+                    ],
+                    "doc": [],
+                    "bz": [
+                        "https://bugzilla.redhat.com/show_bug.cgi?id=1766907"
+                    ]
+                }
+            },
+            {
+                "rule_id": "nodes_kubelet_version_check|NODE_KUBELET_VERSION",
+                "component": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report",
+                "type": "rule",
+                "key": "NODE_KUBELET_VERSION",
+                "details": {
+                    "nodes_with_different_version": [
+                        {
+                            "Node": "oc1",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc2",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc3",
+                            "Kubelet Version": "v1.14.6+d39ad8449",
+                            "role": "worker"
+                        }
+                    ],
+                    "kcs_link": "https://access.redhat.com/solutions/4602641",
+                    "type": "rule",
+                    "error_key": "NODE_KUBELET_VERSION"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4602641"
+                    ]
+                }
+            },
+            {
+                "rule_id": "samples_op_failed_image_import_check|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "component": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report",
+                "type": "rule",
+                "key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "details": {
+                    "info": {
+                        "name": "openshift-samples",
+                        "condition": "Degraded",
+                        "reason": "FailedImageImports",
+                        "message": "Samples installed at 4.2.0, with image import failures for these imagestreams: php ",
+                        "lastTransitionTime": "2020-03-19T08:32:53Z"
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4563171",
+                    "type": "rule",
+                    "error_key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4563171"
+                    ]
+                }
+            },
+            {
+                "rule_id": "cluster_wide_proxy_auth_check|AUTH_OPERATOR_PROXY_ERROR",
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "type": "rule",
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "details": {
+                    "op": {
+                        "available": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "degraded": {
+                            "message": "WellKnownEndpointDegraded: failed to GET well-known https://10.237.112.145:6443/.well-known/oauth-authorization-server: Tunnel or SSL Forbidden",
+                            "reason": "WellKnownEndpointDegradedError",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:42:33Z"
+                        },
+                        "name": "authentication",
+                        "progressing": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "upgradeable": {
+                            "message": null,
+                            "reason": "AsExpected",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "version": null
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4569191",
+                    "type": "rule",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4569191"
+                    ]
+                }
+            }
+        ],
+        "fingerprints": [],
+        "skips": [
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_ocs_version.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_pods_scc.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PodsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.operator_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.pvc_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.get_mon_reporting_clock_skew'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1801300.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1802248.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_no_access.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_low_capacity.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_no_volume_set_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodEmptyDirVolume', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodPersistentVolume'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_not_bound.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            }
+        ],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/10_rules_hits.json
+++ b/messages/invalid_wrong_org_id/10_rules_hits.json
@@ -1,0 +1,264 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 10,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767aa",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.operator_phase_check.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.pvc_phase_check.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.check_pods_scc.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.check_ocs_version.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "component": "ccx_rules_ocp.external.rules.nodes_requirements_check.report",
+                "type": "rule",
+                "key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "details": {
+                    "nodes": [
+                        {
+                            "name": "foo1",
+                            "role": "master",
+                            "memory": 8.16,
+                            "memory_req": 16
+                        }
+                    ],
+                    "link": "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal",
+                    "type": "rule",
+                    "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET"
+                },
+                "tags": [],
+                "links": {
+                    "docs": [
+                        "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal"
+                    ]
+                }
+            },
+            {
+                "rule_id": "bug_1766907|BUGZILLA_BUG_1766907",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1766907.report",
+                "type": "rule",
+                "key": "BUGZILLA_BUG_1766907",
+                "details": {
+                    "type": "rule",
+                    "error_key": "BUGZILLA_BUG_1766907"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4631541"
+                    ],
+                    "doc": [],
+                    "bz": [
+                        "https://bugzilla.redhat.com/show_bug.cgi?id=1766907"
+                    ]
+                }
+            },
+            {
+                "rule_id": "nodes_kubelet_version_check|NODE_KUBELET_VERSION",
+                "component": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report",
+                "type": "rule",
+                "key": "NODE_KUBELET_VERSION",
+                "details": {
+                    "nodes_with_different_version": [
+                        {
+                            "Node": "oc1",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc2",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc3",
+                            "Kubelet Version": "v1.14.6+d39ad8449",
+                            "role": "worker"
+                        }
+                    ],
+                    "kcs_link": "https://access.redhat.com/solutions/4602641",
+                    "type": "rule",
+                    "error_key": "NODE_KUBELET_VERSION"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4602641"
+                    ]
+                }
+            },
+            {
+                "rule_id": "samples_op_failed_image_import_check|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "component": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report",
+                "type": "rule",
+                "key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "details": {
+                    "info": {
+                        "name": "openshift-samples",
+                        "condition": "Degraded",
+                        "reason": "FailedImageImports",
+                        "message": "Samples installed at 4.2.0, with image import failures for these imagestreams: php ",
+                        "lastTransitionTime": "2020-03-19T08:32:53Z"
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4563171",
+                    "type": "rule",
+                    "error_key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4563171"
+                    ]
+                }
+            },
+            {
+                "rule_id": "cluster_wide_proxy_auth_check|AUTH_OPERATOR_PROXY_ERROR",
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "type": "rule",
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "details": {
+                    "op": {
+                        "available": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "degraded": {
+                            "message": "WellKnownEndpointDegraded: failed to GET well-known https://10.237.112.145:6443/.well-known/oauth-authorization-server: Tunnel or SSL Forbidden",
+                            "reason": "WellKnownEndpointDegradedError",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:42:33Z"
+                        },
+                        "name": "authentication",
+                        "progressing": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "upgradeable": {
+                            "message": null,
+                            "reason": "AsExpected",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "version": null
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4569191",
+                    "type": "rule",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4569191"
+                    ]
+                }
+            }
+        ],
+        "fingerprints": [],
+        "skips": [
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1801300.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1802248.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_no_access.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_low_capacity.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_no_volume_set_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodEmptyDirVolume', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodPersistentVolume'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_not_bound.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            }
+        ],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/10_rules_hits_org_1.json
+++ b/messages/invalid_wrong_org_id/10_rules_hits_org_1.json
@@ -1,0 +1,264 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 1,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767ab",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.operator_phase_check.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.pvc_phase_check.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.check_pods_scc.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.check_ocs_version.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "component": "ccx_rules_ocp.external.rules.nodes_requirements_check.report",
+                "type": "rule",
+                "key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "details": {
+                    "nodes": [
+                        {
+                            "name": "foo1",
+                            "role": "master",
+                            "memory": 8.16,
+                            "memory_req": 16
+                        }
+                    ],
+                    "link": "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal",
+                    "type": "rule",
+                    "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET"
+                },
+                "tags": [],
+                "links": {
+                    "docs": [
+                        "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal"
+                    ]
+                }
+            },
+            {
+                "rule_id": "bug_1766907|BUGZILLA_BUG_1766907",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1766907.report",
+                "type": "rule",
+                "key": "BUGZILLA_BUG_1766907",
+                "details": {
+                    "type": "rule",
+                    "error_key": "BUGZILLA_BUG_1766907"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4631541"
+                    ],
+                    "doc": [],
+                    "bz": [
+                        "https://bugzilla.redhat.com/show_bug.cgi?id=1766907"
+                    ]
+                }
+            },
+            {
+                "rule_id": "nodes_kubelet_version_check|NODE_KUBELET_VERSION",
+                "component": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report",
+                "type": "rule",
+                "key": "NODE_KUBELET_VERSION",
+                "details": {
+                    "nodes_with_different_version": [
+                        {
+                            "Node": "oc1",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc2",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc3",
+                            "Kubelet Version": "v1.14.6+d39ad8449",
+                            "role": "worker"
+                        }
+                    ],
+                    "kcs_link": "https://access.redhat.com/solutions/4602641",
+                    "type": "rule",
+                    "error_key": "NODE_KUBELET_VERSION"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4602641"
+                    ]
+                }
+            },
+            {
+                "rule_id": "samples_op_failed_image_import_check|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "component": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report",
+                "type": "rule",
+                "key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "details": {
+                    "info": {
+                        "name": "openshift-samples",
+                        "condition": "Degraded",
+                        "reason": "FailedImageImports",
+                        "message": "Samples installed at 4.2.0, with image import failures for these imagestreams: php ",
+                        "lastTransitionTime": "2020-03-19T08:32:53Z"
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4563171",
+                    "type": "rule",
+                    "error_key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4563171"
+                    ]
+                }
+            },
+            {
+                "rule_id": "cluster_wide_proxy_auth_check|AUTH_OPERATOR_PROXY_ERROR",
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "type": "rule",
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "details": {
+                    "op": {
+                        "available": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "degraded": {
+                            "message": "WellKnownEndpointDegraded: failed to GET well-known https://10.237.112.145:6443/.well-known/oauth-authorization-server: Tunnel or SSL Forbidden",
+                            "reason": "WellKnownEndpointDegradedError",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:42:33Z"
+                        },
+                        "name": "authentication",
+                        "progressing": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "upgradeable": {
+                            "message": null,
+                            "reason": "AsExpected",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "version": null
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4569191",
+                    "type": "rule",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4569191"
+                    ]
+                }
+            }
+        ],
+        "fingerprints": [],
+        "skips": [
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1801300.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1802248.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_no_access.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_low_capacity.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_no_volume_set_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodEmptyDirVolume', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodPersistentVolume'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_not_bound.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            }
+        ],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/15_rules_hits.json
+++ b/messages/invalid_wrong_org_id/15_rules_hits.json
@@ -1,0 +1,294 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 10,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767aa",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1801300.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1802248.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.external.rules.image_registry_pv_no_access.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.external.rules.image_registry_pv_low_capacity.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.external.rules.image_registry_no_volume_set_check.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.operator_phase_check.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.pvc_phase_check.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.check_pods_scc.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.check_ocs_version.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "component": "ccx_rules_ocp.external.rules.nodes_requirements_check.report",
+                "type": "rule",
+                "key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "details": {
+                    "nodes": [
+                        {
+                            "name": "foo1",
+                            "role": "master",
+                            "memory": 8.16,
+                            "memory_req": 16
+                        }
+                    ],
+                    "link": "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal",
+                    "type": "rule",
+                    "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET"
+                },
+                "tags": [],
+                "links": {
+                    "docs": [
+                        "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal"
+                    ]
+                }
+            },
+            {
+                "rule_id": "bug_1766907|BUGZILLA_BUG_1766907",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1766907.report",
+                "type": "rule",
+                "key": "BUGZILLA_BUG_1766907",
+                "details": {
+                    "type": "rule",
+                    "error_key": "BUGZILLA_BUG_1766907"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4631541"
+                    ],
+                    "doc": [],
+                    "bz": [
+                        "https://bugzilla.redhat.com/show_bug.cgi?id=1766907"
+                    ]
+                }
+            },
+            {
+                "rule_id": "nodes_kubelet_version_check|NODE_KUBELET_VERSION",
+                "component": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report",
+                "type": "rule",
+                "key": "NODE_KUBELET_VERSION",
+                "details": {
+                    "nodes_with_different_version": [
+                        {
+                            "Node": "oc1",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc2",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc3",
+                            "Kubelet Version": "v1.14.6+d39ad8449",
+                            "role": "worker"
+                        }
+                    ],
+                    "kcs_link": "https://access.redhat.com/solutions/4602641",
+                    "type": "rule",
+                    "error_key": "NODE_KUBELET_VERSION"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4602641"
+                    ]
+                }
+            },
+            {
+                "rule_id": "samples_op_failed_image_import_check|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "component": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report",
+                "type": "rule",
+                "key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "details": {
+                    "info": {
+                        "name": "openshift-samples",
+                        "condition": "Degraded",
+                        "reason": "FailedImageImports",
+                        "message": "Samples installed at 4.2.0, with image import failures for these imagestreams: php ",
+                        "lastTransitionTime": "2020-03-19T08:32:53Z"
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4563171",
+                    "type": "rule",
+                    "error_key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4563171"
+                    ]
+                }
+            },
+            {
+                "rule_id": "cluster_wide_proxy_auth_check|AUTH_OPERATOR_PROXY_ERROR",
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "type": "rule",
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "details": {
+                    "op": {
+                        "available": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "degraded": {
+                            "message": "WellKnownEndpointDegraded: failed to GET well-known https://10.237.112.145:6443/.well-known/oauth-authorization-server: Tunnel or SSL Forbidden",
+                            "reason": "WellKnownEndpointDegradedError",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:42:33Z"
+                        },
+                        "name": "authentication",
+                        "progressing": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "upgradeable": {
+                            "message": null,
+                            "reason": "AsExpected",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "version": null
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4569191",
+                    "type": "rule",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4569191"
+                    ]
+                }
+            }
+        ],
+        "fingerprints": [],
+        "skips": [
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_not_bound.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            }
+        ],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/15_rules_hits_org_1.json
+++ b/messages/invalid_wrong_org_id/15_rules_hits_org_1.json
@@ -1,0 +1,294 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 1,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767ac",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1801300.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1802248.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.external.rules.image_registry_pv_no_access.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.external.rules.image_registry_pv_low_capacity.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.external.rules.image_registry_no_volume_set_check.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.operator_phase_check.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.pvc_phase_check.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.check_pods_scc.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "foo_check|ERROR_KEY",
+                "component": "ccx_rules_ocp.ocs.check_ocs_version.report",
+                "type": "rule",
+                "key": "ERROR_KEY",
+                "details": {
+                    "type": "rule",
+                    "error_key": "ERROR_KEY"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "component": "ccx_rules_ocp.external.rules.nodes_requirements_check.report",
+                "type": "rule",
+                "key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "details": {
+                    "nodes": [
+                        {
+                            "name": "foo1",
+                            "role": "master",
+                            "memory": 8.16,
+                            "memory_req": 16
+                        }
+                    ],
+                    "link": "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal",
+                    "type": "rule",
+                    "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET"
+                },
+                "tags": [],
+                "links": {
+                    "docs": [
+                        "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal"
+                    ]
+                }
+            },
+            {
+                "rule_id": "bug_1766907|BUGZILLA_BUG_1766907",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1766907.report",
+                "type": "rule",
+                "key": "BUGZILLA_BUG_1766907",
+                "details": {
+                    "type": "rule",
+                    "error_key": "BUGZILLA_BUG_1766907"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4631541"
+                    ],
+                    "doc": [],
+                    "bz": [
+                        "https://bugzilla.redhat.com/show_bug.cgi?id=1766907"
+                    ]
+                }
+            },
+            {
+                "rule_id": "nodes_kubelet_version_check|NODE_KUBELET_VERSION",
+                "component": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report",
+                "type": "rule",
+                "key": "NODE_KUBELET_VERSION",
+                "details": {
+                    "nodes_with_different_version": [
+                        {
+                            "Node": "oc1",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc2",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc3",
+                            "Kubelet Version": "v1.14.6+d39ad8449",
+                            "role": "worker"
+                        }
+                    ],
+                    "kcs_link": "https://access.redhat.com/solutions/4602641",
+                    "type": "rule",
+                    "error_key": "NODE_KUBELET_VERSION"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4602641"
+                    ]
+                }
+            },
+            {
+                "rule_id": "samples_op_failed_image_import_check|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "component": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report",
+                "type": "rule",
+                "key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "details": {
+                    "info": {
+                        "name": "openshift-samples",
+                        "condition": "Degraded",
+                        "reason": "FailedImageImports",
+                        "message": "Samples installed at 4.2.0, with image import failures for these imagestreams: php ",
+                        "lastTransitionTime": "2020-03-19T08:32:53Z"
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4563171",
+                    "type": "rule",
+                    "error_key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4563171"
+                    ]
+                }
+            },
+            {
+                "rule_id": "cluster_wide_proxy_auth_check|AUTH_OPERATOR_PROXY_ERROR",
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "type": "rule",
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "details": {
+                    "op": {
+                        "available": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "degraded": {
+                            "message": "WellKnownEndpointDegraded: failed to GET well-known https://10.237.112.145:6443/.well-known/oauth-authorization-server: Tunnel or SSL Forbidden",
+                            "reason": "WellKnownEndpointDegradedError",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:42:33Z"
+                        },
+                        "name": "authentication",
+                        "progressing": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "upgradeable": {
+                            "message": null,
+                            "reason": "AsExpected",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "version": null
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4569191",
+                    "type": "rule",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4569191"
+                    ]
+                }
+            }
+        ],
+        "fingerprints": [],
+        "skips": [
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_not_bound.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            }
+        ],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/big_results.json
+++ b/messages/invalid_wrong_org_id/big_results.json
@@ -1,0 +1,234 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 10,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767aa",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "component": "ccx_rules_ocp.external.rules.nodes_requirements_check.report",
+                "type": "rule",
+                "key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "details": {
+                    "nodes": [
+                        {
+                            "name": "foo1",
+                            "role": "master",
+                            "memory": 8.16,
+                            "memory_req": 16
+                        }
+                    ],
+                    "link": "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal",
+                    "type": "rule",
+                    "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET"
+                },
+                "tags": [],
+                "links": {
+                    "docs": [
+                        "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal"
+                    ]
+                }
+            },
+            {
+                "rule_id": "bug_1766907|BUGZILLA_BUG_1766907",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1766907.report",
+                "type": "rule",
+                "key": "BUGZILLA_BUG_1766907",
+                "details": {
+                    "type": "rule",
+                    "error_key": "BUGZILLA_BUG_1766907"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4631541"
+                    ],
+                    "doc": [],
+                    "bz": [
+                        "https://bugzilla.redhat.com/show_bug.cgi?id=1766907"
+                    ]
+                }
+            },
+            {
+                "rule_id": "nodes_kubelet_version_check|NODE_KUBELET_VERSION",
+                "component": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report",
+                "type": "rule",
+                "key": "NODE_KUBELET_VERSION",
+                "details": {
+                    "nodes_with_different_version": [
+                        {
+                            "Node": "oc1",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc2",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc3",
+                            "Kubelet Version": "v1.14.6+d39ad8449",
+                            "role": "worker"
+                        }
+                    ],
+                    "kcs_link": "https://access.redhat.com/solutions/4602641",
+                    "type": "rule",
+                    "error_key": "NODE_KUBELET_VERSION"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4602641"
+                    ]
+                }
+            },
+            {
+                "rule_id": "samples_op_failed_image_import_check|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "component": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report",
+                "type": "rule",
+                "key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "details": {
+                    "info": {
+                        "name": "openshift-samples",
+                        "condition": "Degraded",
+                        "reason": "FailedImageImports",
+                        "message": "Samples installed at 4.2.0, with image import failures for these imagestreams: php ",
+                        "lastTransitionTime": "2020-03-19T08:32:53Z"
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4563171",
+                    "type": "rule",
+                    "error_key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4563171"
+                    ]
+                }
+            },
+            {
+                "rule_id": "cluster_wide_proxy_auth_check|AUTH_OPERATOR_PROXY_ERROR",
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "type": "rule",
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "details": {
+                    "op": {
+                        "available": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "degraded": {
+                            "message": "WellKnownEndpointDegraded: failed to GET well-known https://10.237.112.145:6443/.well-known/oauth-authorization-server: Tunnel or SSL Forbidden",
+                            "reason": "WellKnownEndpointDegradedError",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:42:33Z"
+                        },
+                        "name": "authentication",
+                        "progressing": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "upgradeable": {
+                            "message": null,
+                            "reason": "AsExpected",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "version": null
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4569191",
+                    "type": "rule",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4569191"
+                    ]
+                }
+            }
+        ],
+        "fingerprints": [],
+        "skips": [
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_ocs_version.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_pods_scc.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PodsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.operator_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.pvc_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.get_mon_reporting_clock_skew'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1801300.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1802248.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_no_access.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_low_capacity.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_no_volume_set_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodEmptyDirVolume', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodPersistentVolume'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_not_bound.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            }
+        ],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/big_results_no_skips.json
+++ b/messages/invalid_wrong_org_id/big_results_no_skips.json
@@ -1,0 +1,167 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 10,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767aa",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "component": "ccx_rules_ocp.external.rules.nodes_requirements_check.report",
+                "type": "rule",
+                "key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "details": {
+                    "nodes": [
+                        {
+                            "name": "foo1",
+                            "role": "master",
+                            "memory": 8.16,
+                            "memory_req": 16
+                        }
+                    ],
+                    "link": "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal",
+                    "type": "rule",
+                    "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET"
+                },
+                "tags": [],
+                "links": {
+                    "docs": [
+                        "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal"
+                    ]
+                }
+            },
+            {
+                "rule_id": "bug_1766907|BUGZILLA_BUG_1766907",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1766907.report",
+                "type": "rule",
+                "key": "BUGZILLA_BUG_1766907",
+                "details": {
+                    "type": "rule",
+                    "error_key": "BUGZILLA_BUG_1766907"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4631541"
+                    ],
+                    "doc": [],
+                    "bz": [
+                        "https://bugzilla.redhat.com/show_bug.cgi?id=1766907"
+                    ]
+                }
+            },
+            {
+                "rule_id": "nodes_kubelet_version_check|NODE_KUBELET_VERSION",
+                "component": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report",
+                "type": "rule",
+                "key": "NODE_KUBELET_VERSION",
+                "details": {
+                    "nodes_with_different_version": [
+                        {
+                            "Node": "oc1",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc2",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc3",
+                            "Kubelet Version": "v1.14.6+d39ad8449",
+                            "role": "worker"
+                        }
+                    ],
+                    "kcs_link": "https://access.redhat.com/solutions/4602641",
+                    "type": "rule",
+                    "error_key": "NODE_KUBELET_VERSION"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4602641"
+                    ]
+                }
+            },
+            {
+                "rule_id": "samples_op_failed_image_import_check|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "component": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report",
+                "type": "rule",
+                "key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "details": {
+                    "info": {
+                        "name": "openshift-samples",
+                        "condition": "Degraded",
+                        "reason": "FailedImageImports",
+                        "message": "Samples installed at 4.2.0, with image import failures for these imagestreams: php ",
+                        "lastTransitionTime": "2020-03-19T08:32:53Z"
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4563171",
+                    "type": "rule",
+                    "error_key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4563171"
+                    ]
+                }
+            },
+            {
+                "rule_id": "cluster_wide_proxy_auth_check|AUTH_OPERATOR_PROXY_ERROR",
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "type": "rule",
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "details": {
+                    "op": {
+                        "available": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "degraded": {
+                            "message": "WellKnownEndpointDegraded: failed to GET well-known https://10.237.112.145:6443/.well-known/oauth-authorization-server: Tunnel or SSL Forbidden",
+                            "reason": "WellKnownEndpointDegradedError",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:42:33Z"
+                        },
+                        "name": "authentication",
+                        "progressing": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "upgradeable": {
+                            "message": null,
+                            "reason": "AsExpected",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "version": null
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4569191",
+                    "type": "rule",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4569191"
+                    ]
+                }
+            }
+        ],
+        "fingerprints": [],
+        "skips": [],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/big_results_no_skips_tutorial.json
+++ b/messages/invalid_wrong_org_id/big_results_no_skips_tutorial.json
@@ -1,0 +1,179 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 10,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767aa",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "tutorial_rule|TUTORIAL_ERROR",
+                "component": "ccx_rules_ocp.external.rules.tutorial_rule.report",
+                "type": "rule",
+                "key": "TUTORIAL_ERROR",
+                "details": {
+                    "type": "rule",
+                    "error_key": "TUTORIAL_ERROR"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "component": "ccx_rules_ocp.external.rules.nodes_requirements_check.report",
+                "type": "rule",
+                "key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "details": {
+                    "nodes": [
+                        {
+                            "name": "foo1",
+                            "role": "master",
+                            "memory": 8.16,
+                            "memory_req": 16
+                        }
+                    ],
+                    "link": "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal",
+                    "type": "rule",
+                    "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET"
+                },
+                "tags": [],
+                "links": {
+                    "docs": [
+                        "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal"
+                    ]
+                }
+            },
+            {
+                "rule_id": "bug_1766907|BUGZILLA_BUG_1766907",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1766907.report",
+                "type": "rule",
+                "key": "BUGZILLA_BUG_1766907",
+                "details": {
+                    "type": "rule",
+                    "error_key": "BUGZILLA_BUG_1766907"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4631541"
+                    ],
+                    "doc": [],
+                    "bz": [
+                        "https://bugzilla.redhat.com/show_bug.cgi?id=1766907"
+                    ]
+                }
+            },
+            {
+                "rule_id": "nodes_kubelet_version_check|NODE_KUBELET_VERSION",
+                "component": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report",
+                "type": "rule",
+                "key": "NODE_KUBELET_VERSION",
+                "details": {
+                    "nodes_with_different_version": [
+                        {
+                            "Node": "oc1",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc2",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc3",
+                            "Kubelet Version": "v1.14.6+d39ad8449",
+                            "role": "worker"
+                        }
+                    ],
+                    "kcs_link": "https://access.redhat.com/solutions/4602641",
+                    "type": "rule",
+                    "error_key": "NODE_KUBELET_VERSION"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4602641"
+                    ]
+                }
+            },
+            {
+                "rule_id": "samples_op_failed_image_import_check|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "component": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report",
+                "type": "rule",
+                "key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "details": {
+                    "info": {
+                        "name": "openshift-samples",
+                        "condition": "Degraded",
+                        "reason": "FailedImageImports",
+                        "message": "Samples installed at 4.2.0, with image import failures for these imagestreams: php ",
+                        "lastTransitionTime": "2020-03-19T08:32:53Z"
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4563171",
+                    "type": "rule",
+                    "error_key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4563171"
+                    ]
+                }
+            },
+            {
+                "rule_id": "cluster_wide_proxy_auth_check|AUTH_OPERATOR_PROXY_ERROR",
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "type": "rule",
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "details": {
+                    "op": {
+                        "available": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "degraded": {
+                            "message": "WellKnownEndpointDegraded: failed to GET well-known https://10.237.112.145:6443/.well-known/oauth-authorization-server: Tunnel or SSL Forbidden",
+                            "reason": "WellKnownEndpointDegradedError",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:42:33Z"
+                        },
+                        "name": "authentication",
+                        "progressing": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "upgradeable": {
+                            "message": null,
+                            "reason": "AsExpected",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "version": null
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4569191",
+                    "type": "rule",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4569191"
+                    ]
+                }
+            }
+        ],
+        "fingerprints": [],
+        "skips": [],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/big_results_org_1.json
+++ b/messages/invalid_wrong_org_id/big_results_org_1.json
@@ -1,0 +1,234 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 1,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767ad",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "component": "ccx_rules_ocp.external.rules.nodes_requirements_check.report",
+                "type": "rule",
+                "key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "details": {
+                    "nodes": [
+                        {
+                            "name": "foo1",
+                            "role": "master",
+                            "memory": 8.16,
+                            "memory_req": 16
+                        }
+                    ],
+                    "link": "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal",
+                    "type": "rule",
+                    "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET"
+                },
+                "tags": [],
+                "links": {
+                    "docs": [
+                        "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal"
+                    ]
+                }
+            },
+            {
+                "rule_id": "bug_1766907|BUGZILLA_BUG_1766907",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1766907.report",
+                "type": "rule",
+                "key": "BUGZILLA_BUG_1766907",
+                "details": {
+                    "type": "rule",
+                    "error_key": "BUGZILLA_BUG_1766907"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4631541"
+                    ],
+                    "doc": [],
+                    "bz": [
+                        "https://bugzilla.redhat.com/show_bug.cgi?id=1766907"
+                    ]
+                }
+            },
+            {
+                "rule_id": "nodes_kubelet_version_check|NODE_KUBELET_VERSION",
+                "component": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report",
+                "type": "rule",
+                "key": "NODE_KUBELET_VERSION",
+                "details": {
+                    "nodes_with_different_version": [
+                        {
+                            "Node": "oc1",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc2",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc3",
+                            "Kubelet Version": "v1.14.6+d39ad8449",
+                            "role": "worker"
+                        }
+                    ],
+                    "kcs_link": "https://access.redhat.com/solutions/4602641",
+                    "type": "rule",
+                    "error_key": "NODE_KUBELET_VERSION"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4602641"
+                    ]
+                }
+            },
+            {
+                "rule_id": "samples_op_failed_image_import_check|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "component": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report",
+                "type": "rule",
+                "key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "details": {
+                    "info": {
+                        "name": "openshift-samples",
+                        "condition": "Degraded",
+                        "reason": "FailedImageImports",
+                        "message": "Samples installed at 4.2.0, with image import failures for these imagestreams: php ",
+                        "lastTransitionTime": "2020-03-19T08:32:53Z"
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4563171",
+                    "type": "rule",
+                    "error_key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4563171"
+                    ]
+                }
+            },
+            {
+                "rule_id": "cluster_wide_proxy_auth_check|AUTH_OPERATOR_PROXY_ERROR",
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "type": "rule",
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "details": {
+                    "op": {
+                        "available": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "degraded": {
+                            "message": "WellKnownEndpointDegraded: failed to GET well-known https://10.237.112.145:6443/.well-known/oauth-authorization-server: Tunnel or SSL Forbidden",
+                            "reason": "WellKnownEndpointDegradedError",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:42:33Z"
+                        },
+                        "name": "authentication",
+                        "progressing": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "upgradeable": {
+                            "message": null,
+                            "reason": "AsExpected",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "version": null
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4569191",
+                    "type": "rule",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4569191"
+                    ]
+                }
+            }
+        ],
+        "fingerprints": [],
+        "skips": [
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_ocs_version.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_pods_scc.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PodsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.operator_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.pvc_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.get_mon_reporting_clock_skew'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1801300.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1802248.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_no_access.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_low_capacity.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_no_volume_set_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodEmptyDirVolume', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodPersistentVolume'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_not_bound.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            }
+        ],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/big_results_tutorial.json
+++ b/messages/invalid_wrong_org_id/big_results_tutorial.json
@@ -1,0 +1,246 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 10,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767aa",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "tutorial_rule|TUTORIAL_ERROR",
+                "component": "ccx_rules_ocp.external.rules.tutorial_rule.report",
+                "type": "rule",
+                "key": "TUTORIAL_ERROR",
+                "details": {
+                    "type": "rule",
+                    "error_key": "TUTORIAL_ERROR"
+                },
+                "tags": [],
+                "links": {}
+            },
+            {
+                "rule_id": "nodes_requirements_check|NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "component": "ccx_rules_ocp.external.rules.nodes_requirements_check.report",
+                "type": "rule",
+                "key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
+                "details": {
+                    "nodes": [
+                        {
+                            "name": "foo1",
+                            "role": "master",
+                            "memory": 8.16,
+                            "memory_req": 16
+                        }
+                    ],
+                    "link": "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal",
+                    "type": "rule",
+                    "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET"
+                },
+                "tags": [],
+                "links": {
+                    "docs": [
+                        "https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal"
+                    ]
+                }
+            },
+            {
+                "rule_id": "bug_1766907|BUGZILLA_BUG_1766907",
+                "component": "ccx_rules_ocp.external.bug_rules.bug_1766907.report",
+                "type": "rule",
+                "key": "BUGZILLA_BUG_1766907",
+                "details": {
+                    "type": "rule",
+                    "error_key": "BUGZILLA_BUG_1766907"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4631541"
+                    ],
+                    "doc": [],
+                    "bz": [
+                        "https://bugzilla.redhat.com/show_bug.cgi?id=1766907"
+                    ]
+                }
+            },
+            {
+                "rule_id": "nodes_kubelet_version_check|NODE_KUBELET_VERSION",
+                "component": "ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report",
+                "type": "rule",
+                "key": "NODE_KUBELET_VERSION",
+                "details": {
+                    "nodes_with_different_version": [
+                        {
+                            "Node": "oc1",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc2",
+                            "Kubelet Version": "v1.14.6+0a21dd3b3",
+                            "role": "worker"
+                        },
+                        {
+                            "Node": "oc3",
+                            "Kubelet Version": "v1.14.6+d39ad8449",
+                            "role": "worker"
+                        }
+                    ],
+                    "kcs_link": "https://access.redhat.com/solutions/4602641",
+                    "type": "rule",
+                    "error_key": "NODE_KUBELET_VERSION"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4602641"
+                    ]
+                }
+            },
+            {
+                "rule_id": "samples_op_failed_image_import_check|SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "component": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report",
+                "type": "rule",
+                "key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR",
+                "details": {
+                    "info": {
+                        "name": "openshift-samples",
+                        "condition": "Degraded",
+                        "reason": "FailedImageImports",
+                        "message": "Samples installed at 4.2.0, with image import failures for these imagestreams: php ",
+                        "lastTransitionTime": "2020-03-19T08:32:53Z"
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4563171",
+                    "type": "rule",
+                    "error_key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4563171"
+                    ]
+                }
+            },
+            {
+                "rule_id": "cluster_wide_proxy_auth_check|AUTH_OPERATOR_PROXY_ERROR",
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "type": "rule",
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "details": {
+                    "op": {
+                        "available": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "degraded": {
+                            "message": "WellKnownEndpointDegraded: failed to GET well-known https://10.237.112.145:6443/.well-known/oauth-authorization-server: Tunnel or SSL Forbidden",
+                            "reason": "WellKnownEndpointDegradedError",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:42:33Z"
+                        },
+                        "name": "authentication",
+                        "progressing": {
+                            "message": null,
+                            "reason": "NoData",
+                            "status": null,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "upgradeable": {
+                            "message": null,
+                            "reason": "AsExpected",
+                            "status": true,
+                            "last_trans_time": "2020-03-31T08:39:51Z"
+                        },
+                        "version": null
+                    },
+                    "kcs": "https://access.redhat.com/solutions/4569191",
+                    "type": "rule",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR"
+                },
+                "tags": [],
+                "links": {
+                    "kcs": [
+                        "https://access.redhat.com/solutions/4569191"
+                    ]
+                }
+            }
+        ],
+        "fingerprints": [],
+        "skips": [
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_ocs_version.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_pods_scc.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PodsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.operator_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.pvc_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.get_mon_reporting_clock_skew'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1801300.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1802248.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_no_access.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_low_capacity.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_no_volume_set_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodEmptyDirVolume', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodPersistentVolume'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_not_bound.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            }
+        ],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/no_hits.json
+++ b/messages/invalid_wrong_org_id/no_hits.json
@@ -1,0 +1,85 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 10,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767aa",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [],
+        "fingerprints": [],
+        "skips": [
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_ocs_version.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_pods_scc.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PodsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.operator_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.pvc_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.get_mon_reporting_clock_skew'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1801300.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.bug_rules.bug_1802248.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather.DeploymentsMG'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_no_access.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_low_capacity.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_no_volume_set_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodEmptyDirVolume', 'ccx_rules_ocp.common.conditions.image_registry.isImageRegistryPodPersistentVolume'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.external.rules.image_registry_pv_not_bound.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.common.conditions.image_registry.DegradedImageRegistryOperator', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPod', 'ccx_rules_ocp.common.conditions.image_registry.ImageRegistryPersistentVolumeClaim'] Any: ",
+                "type": "skip"
+            }
+        ],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/no_hits_no_skips.json
+++ b/messages/invalid_wrong_org_id/no_hits_no_skips.json
@@ -1,0 +1,18 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 10,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767aa",
+    "LastChecked": "2020-04-02T09:00:05.268294Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [],
+        "fingerprints": [],
+        "skips": [],
+        "info": [],
+        "pass": []
+    }
+}

--- a/messages/invalid_wrong_org_id/result01.json
+++ b/messages/invalid_wrong_org_id/result01.json
@@ -1,0 +1,177 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 20,
+    "ClusterName": "b0c2d108-0603-41c3-9a8f-0a37eba5df49",
+    "LastChecked": "2020-01-23T16:15:59.478901889Z",
+    "Version": 2,
+    "Report": {
+        "fingerprints": [],
+        "info": [
+            {
+                "component": "ocp.rules.cluster_id.report",
+                "details": {
+                    "cluster_id": "b0c2d108-0603-41c3-9a8f-0a37eba5df49",
+                    "grafana_link": "N/A",
+                    "info_key": "GRAFANA_LINK",
+                    "type": "info"
+                },
+                "info_id": "cluster_id|GRAFANA_LINK",
+                "key": "GRAFANA_LINK",
+                "links": {},
+                "tags": [],
+                "type": "info"
+            },
+            {
+                "component": "ocp.rules.version_info.report",
+                "details": {
+                    "current": "4.3.0-0.ci-2020-01-06-150524",
+                    "desired": "4.3.0-0.ci-2020-01-11-070221",
+                    "info_key": "CLUSTER_VERSION_INFO",
+                    "type": "info",
+                    "update_time": "5 days 8 hours 42 minutes 51 seconds"
+                },
+                "info_id": "version_info|CLUSTER_VERSION_INFO",
+                "key": "CLUSTER_VERSION_INFO",
+                "links": {},
+                "tags": [],
+                "type": "info"
+            }
+        ],
+        "reports": [
+            {
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "details": {
+                    "current": "4.3.0-0.ci-2020-01-06-150524",
+                    "desired": "4.3.0-0.ci-2020-01-11-070221",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR",
+                    "type": "rule"
+                },
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "links": {},
+                "rule_id": "version_check|AUTH_OPERATOR_PROXY_ERROR",
+                "tags": [],
+                "type": "rule"
+            }
+        ],
+        "skips": [
+            {
+                "details": "All: ['ocp.metrics.version.VersionMetric', 'ocp.metrics.version_available_updates.VersionAvailableUpdatesMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.version_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.ocs.pvc_phase_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.metrics.version.VersionMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.version_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.metrics.subscription_labels.SubscriptionLabelsMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.support_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool', 'ocp.specs.must_gather.OCVersionCurrentLogs'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_update_stuck.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.events.Events'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.event_nfs_conf.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_pool_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_expiration.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_validity.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_pool_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_check_containers.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_pressure_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.operators.Operators'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.unable_to_sync_storage.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_crash_loop_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_requirements_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.operators.Operators'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.operators_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_check.report",
+                "type": "skip"
+            }
+        ],
+        "system": {
+            "hostname": null,
+            "metadata": {}
+        }
+    }
+}

--- a/messages/invalid_wrong_org_id/result02.json
+++ b/messages/invalid_wrong_org_id/result02.json
@@ -1,0 +1,177 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 1,
+    "ClusterName": "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff",
+    "LastChecked": "2020-01-23T16:15:59.478901889Z",
+    "Version": 2,
+    "Report": {
+        "fingerprints": [],
+        "info": [
+            {
+                "component": "ocp.rules.cluster_id.report",
+                "details": {
+                    "cluster_id": "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff",
+                    "grafana_link": "N/A",
+                    "info_key": "GRAFANA_LINK",
+                    "type": "info"
+                },
+                "info_id": "cluster_id|GRAFANA_LINK",
+                "key": "GRAFANA_LINK",
+                "links": {},
+                "tags": [],
+                "type": "info"
+            },
+            {
+                "component": "ocp.rules.version_info.report",
+                "details": {
+                    "current": "4.4.0-0.ci-2020-01-13-120251",
+                    "desired": "4.4.0-0.ci-2020-01-13-142741",
+                    "info_key": "CLUSTER_VERSION_INFO",
+                    "type": "info",
+                    "update_time": "23 minutes 31 seconds"
+                },
+                "info_id": "version_info|CLUSTER_VERSION_INFO",
+                "key": "CLUSTER_VERSION_INFO",
+                "links": {},
+                "tags": [],
+                "type": "info"
+            }
+        ],
+        "reports": [
+            {
+                "component": "ocp.rules.version_check.report",
+                "details": {
+                    "current": "4.4.0-0.ci-2020-01-13-120251",
+                    "desired": "4.4.0-0.ci-2020-01-13-142741",
+                    "error_key": "CLUSTER_VERSION_DESIRED",
+                    "type": "rule"
+                },
+                "key": "CLUSTER_VERSION_DESIRED",
+                "links": {},
+                "rule_id": "version_check|CLUSTER_VERSION_DESIRED",
+                "tags": [],
+                "type": "rule"
+            }
+        ],
+        "skips": [
+            {
+                "details": "All: ['ocp.metrics.version.VersionMetric', 'ocp.metrics.version_available_updates.VersionAvailableUpdatesMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.version_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.ocs.pvc_phase_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.metrics.version.VersionMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.version_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.metrics.subscription_labels.SubscriptionLabelsMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.support_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.events.Events'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.event_nfs_conf.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_pool_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool', 'ocp.specs.must_gather.OCVersionCurrentLogs'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_update_stuck.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_expiration.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_validity.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_pool_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_check_containers.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_pressure_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.operators.Operators'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.unable_to_sync_storage.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_crash_loop_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_requirements_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.operators.Operators'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.operators_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_check.report",
+                "type": "skip"
+            }
+        ],
+        "system": {
+            "hostname": null,
+            "metadata": {}
+        }
+    }
+}

--- a/messages/invalid_wrong_org_id/result03.json
+++ b/messages/invalid_wrong_org_id/result03.json
@@ -1,0 +1,177 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 2,
+    "ClusterName": "22222222-bbbb-cccc-dddd-ffffffffffff",
+    "LastChecked": "2020-01-23T16:15:59.478901889Z",
+    "Version": 2,
+    "Report": {
+        "fingerprints": [],
+        "info": [
+            {
+                "component": "ocp.rules.cluster_id.report",
+                "details": {
+                    "cluster_id": "22222222-bbbb-cccc-dddd-ffffffffffff",
+                    "grafana_link": "N/A",
+                    "info_key": "GRAFANA_LINK",
+                    "type": "info"
+                },
+                "info_id": "cluster_id|GRAFANA_LINK",
+                "key": "GRAFANA_LINK",
+                "links": {},
+                "tags": [],
+                "type": "info"
+            },
+            {
+                "component": "ocp.rules.version_info.report",
+                "details": {
+                    "current": "4.4.0-0.ci-2020-01-13-152741",
+                    "desired": "4.4.0-0.ci-2020-01-13-185732",
+                    "info_key": "CLUSTER_VERSION_INFO",
+                    "type": "info",
+                    "update_time": "24 minutes 36 seconds"
+                },
+                "info_id": "version_info|CLUSTER_VERSION_INFO",
+                "key": "CLUSTER_VERSION_INFO",
+                "links": {},
+                "tags": [],
+                "type": "info"
+            }
+        ],
+        "reports": [
+            {
+                "component": "ocp.rules.version_check.report",
+                "details": {
+                    "current": "4.4.0-0.ci-2020-01-13-152741",
+                    "desired": "4.4.0-0.ci-2020-01-13-185732",
+                    "error_key": "CLUSTER_VERSION_DESIRED",
+                    "type": "rule"
+                },
+                "key": "CLUSTER_VERSION_DESIRED",
+                "links": {},
+                "rule_id": "version_check|CLUSTER_VERSION_DESIRED",
+                "tags": [],
+                "type": "rule"
+            }
+        ],
+        "skips": [
+            {
+                "details": "All: ['ocp.metrics.version.VersionMetric', 'ocp.metrics.version_available_updates.VersionAvailableUpdatesMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.version_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.ocs.pvc_phase_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.metrics.version.VersionMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.version_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.metrics.subscription_labels.SubscriptionLabelsMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.support_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.events.Events'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.event_nfs_conf.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_pool_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_expiration.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_validity.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_pool_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool', 'ocp.specs.must_gather.OCVersionCurrentLogs'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_update_stuck.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_check_containers.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_pressure_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.operators.Operators'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.unable_to_sync_storage.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_crash_loop_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_requirements_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.operators.Operators'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.operators_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_check.report",
+                "type": "skip"
+            }
+        ],
+        "system": {
+            "hostname": null,
+            "metadata": {}
+        }
+    }
+}

--- a/messages/invalid_wrong_org_id/result04.json
+++ b/messages/invalid_wrong_org_id/result04.json
@@ -1,0 +1,177 @@
+{
+    "ClusterName": "33333333-bbbb-cccc-dddd-ffffffffffff",
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 3,
+    "LastChecked": "2020-01-23T16:15:59.478901889Z",
+    "Version": 2,
+    "Report": {
+        "fingerprints": [],
+        "info": [
+            {
+                "component": "ocp.rules.cluster_id.report",
+                "details": {
+                    "cluster_id": "33333333-bbbb-cccc-dddd-ffffffffffff",
+                    "grafana_link": "",
+                    "info_key": "GRAFANA_LINK",
+                    "type": "info"
+                },
+                "info_id": "cluster_id|GRAFANA_LINK",
+                "key": "GRAFANA_LINK",
+                "links": {},
+                "tags": [],
+                "type": "info"
+            },
+            {
+                "component": "ocp.rules.version_info.report",
+                "details": {
+                    "current": "4.4.0-0.ci-2020-01-13-195732",
+                    "desired": "4.4.0-0.ci-2020-01-14-154424",
+                    "info_key": "CLUSTER_VERSION_INFO",
+                    "type": "info",
+                    "update_time": "22 minutes 57 seconds"
+                },
+                "info_id": "version_info|CLUSTER_VERSION_INFO",
+                "key": "CLUSTER_VERSION_INFO",
+                "links": {},
+                "tags": [],
+                "type": "info"
+            }
+        ],
+        "reports": [
+            {
+                "component": "ocp.rules.version_check.report",
+                "details": {
+                    "current": "4.4.0-0.ci-2020-01-13-195732",
+                    "desired": "4.4.0-0.ci-2020-01-14-154424",
+                    "error_key": "CLUSTER_VERSION_DESIRED",
+                    "type": "rule"
+                },
+                "key": "CLUSTER_VERSION_DESIRED",
+                "links": {},
+                "rule_id": "version_check|CLUSTER_VERSION_DESIRED",
+                "tags": [],
+                "type": "rule"
+            }
+        ],
+        "skips": [
+            {
+                "details": "All: ['ocp.metrics.version.VersionMetric', 'ocp.metrics.version_available_updates.VersionAvailableUpdatesMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.version_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.ocs.pvc_phase_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.metrics.version.VersionMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.version_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.metrics.subscription_labels.SubscriptionLabelsMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.support_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool', 'ocp.specs.must_gather.OCVersionCurrentLogs'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_update_stuck.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.events.Events'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.event_nfs_conf.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_pool_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_expiration.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_validity.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_pool_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_check_containers.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_pressure_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.operators.Operators'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.unable_to_sync_storage.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_crash_loop_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_requirements_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.operators.Operators'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.operators_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_check.report",
+                "type": "skip"
+            }
+        ],
+        "system": {
+            "hostname": null,
+            "metadata": {}
+        }
+    }
+}

--- a/messages/invalid_wrong_org_id/result05.json
+++ b/messages/invalid_wrong_org_id/result05.json
@@ -1,0 +1,177 @@
+{
+    "ClusterName": "33333333-aaaa-cccc-dddd-ffffffffffff",
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 3,
+    "LastChecked": "2020-01-23T16:15:59.478901889Z",
+    "Version": 2,
+    "Report": {
+        "fingerprints": [],
+        "info": [
+            {
+                "component": "ocp.rules.cluster_id.report",
+                "details": {
+                    "cluster_id": "33333333-aaaa-cccc-dddd-ffffffffffff",
+                    "grafana_link": "",
+                    "info_key": "GRAFANA_LINK",
+                    "type": "info"
+                },
+                "info_id": "cluster_id|GRAFANA_LINK",
+                "key": "GRAFANA_LINK",
+                "links": {},
+                "tags": [],
+                "type": "info"
+            },
+            {
+                "component": "ocp.rules.version_info.report",
+                "details": {
+                    "current": "4.4.0-0.ci-2020-01-13-195732",
+                    "desired": "4.4.0-0.ci-2020-01-14-154424",
+                    "info_key": "CLUSTER_VERSION_INFO",
+                    "type": "info",
+                    "update_time": "22 minutes 57 seconds"
+                },
+                "info_id": "version_info|CLUSTER_VERSION_INFO",
+                "key": "CLUSTER_VERSION_INFO",
+                "links": {},
+                "tags": [],
+                "type": "info"
+            }
+        ],
+        "reports": [
+            {
+                "component": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report",
+                "details": {
+                    "current": "enabled",
+                    "desired": "disabled",
+                    "error_key": "AUTH_OPERATOR_PROXY_ERROR",
+                    "type": "rule"
+                },
+                "key": "AUTH_OPERATOR_PROXY_ERROR",
+                "links": {},
+                "rule_id": "cluster_wide_proxy_auth_check|CLUSTER_VERSION_DESIRED",
+                "tags": [],
+                "type": "rule"
+            }
+        ],
+        "skips": [
+            {
+                "details": "All: ['ocp.metrics.version.VersionMetric', 'ocp.metrics.version_available_updates.VersionAvailableUpdatesMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.version_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.ocs.pvc_phase_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.metrics.version.VersionMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.version_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.metrics.subscription_labels.SubscriptionLabelsMetric'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.telemetry.support_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool', 'ocp.specs.must_gather.OCVersionCurrentLogs'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_update_stuck.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.events.Events'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.event_nfs_conf.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_pool_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_expiration.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.certificates.Certificates'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.certificates_validity.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.machine_pools.MachinePool'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.machine_pool_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_info.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_check_containers.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_pressure_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.operators.Operators'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.unable_to_sync_storage.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_crash_loop_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.nodes.Nodes'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.nodes_requirements_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.operators.Operators'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.operators_check.report",
+                "type": "skip"
+            },
+            {
+                "details": "All: ['ocp.models.pods.Pods'] Any: ",
+                "reason": "MISSING_REQUIREMENTS",
+                "rule_fqdn": "ocp.rules.pods_check.report",
+                "type": "skip"
+            }
+        ],
+        "system": {
+            "hostname": null,
+            "metadata": {}
+        }
+    }
+}

--- a/messages/invalid_wrong_org_id/tutorial_only.json
+++ b/messages/invalid_wrong_org_id/tutorial_only.json
@@ -1,0 +1,62 @@
+{
+    "OrgID": "wrong-organization-id",
+    "AccountNumber": 10,
+    "ClusterName": "5d5892d3-1f74-4ccf-91af-548dfc9767aa",
+    "LastChecked": "2020-04-09T06:16:02.512755Z",
+    "Version": 2,
+    "Report": {
+        "system": {
+            "metadata": {},
+            "hostname": null
+        },
+        "reports": [
+            {
+                "rule_id": "tutorial_rule|TUTORIAL_ERROR",
+                "component": "ccx_rules_ocp.external.tutorial_rule.report",
+                "type": "rule",
+                "key": "TUTORIAL_ERROR",
+                "details": {
+                    "type": "rule",
+                    "error_key": "TUTORIAL_ERROR"
+                },
+                "tags": [],
+                "links": {}
+            }
+        ],
+        "fingerprints": [],
+        "skips": [
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_ocs_version.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.check_pods_scc.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PodsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.operator_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.OperatorsOcsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.pvc_phase_check.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_ocp_core.specs.must_gather_ocs.PersistentVolumeClaimsMGOCS'] Any: ",
+                "type": "skip"
+            },
+            {
+                "rule_fqdn": "ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report",
+                "reason": "MISSING_REQUIREMENTS",
+                "details": "All: ['ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.get_mon_reporting_clock_skew'] Any: ",
+                "type": "skip"
+            }
+        ],
+        "info": [],
+        "pass": []
+    }
+}


### PR DESCRIPTION
# Description

Messages with wrong `org_id` attribute in order to be able to test external data pipeline**

Fixes #114

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

N/A