### PR TITLE
Using types from new package where possible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/RedHatInsights/insights-results-aggregator-data
 
-go 1.14
+go 1.16
 
 require (
-	github.com/RedHatInsights/insights-operator-utils v1.21.2
+	github.com/RedHatInsights/insights-operator-utils v1.21.8
+	github.com/RedHatInsights/insights-results-types v1.2.0
 	github.com/google/uuid v1.1.2
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/RedHatInsights/insights-operator-utils v1.21.0 h1:P688UpKrbLJ5pbLj0j3
 github.com/RedHatInsights/insights-operator-utils v1.21.0/go.mod h1:B2hizFGwXCc8MT34QqVJ1A8ANTyGQZQWXQw/gSCEsaU=
 github.com/RedHatInsights/insights-operator-utils v1.21.2 h1:xE2VyoOr+7LWAT59D234/n4PW6PlkV1wAOrJPDtCOoE=
 github.com/RedHatInsights/insights-operator-utils v1.21.2/go.mod h1:3Pfsgsi7GCu2wgIqQlt1llpyQyyxsDWEGdgnPvadM40=
+github.com/RedHatInsights/insights-operator-utils v1.21.8 h1:VF6d1pFjUwerUUEauC8dEccYowEw3TT7fkcu5OCK4r0=
+github.com/RedHatInsights/insights-operator-utils v1.21.8/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
@@ -45,6 +47,9 @@ github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720
 github.com/RedHatInsights/insights-results-aggregator-data v1.0.1-0.20210614072933-b25730b1e023/go.mod h1:SDeBuNY8AIwkD4JB5/I54ArWG7qngP5/Ydn7xbu2iZo=
 github.com/RedHatInsights/insights-results-aggregator-data v1.1.2/go.mod h1:rbiccYJ8whbpLLvNGMiaFzyMPs1A/2/Jh0P2U9DXF+4=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.1/go.mod h1:Ylo2cWFmraBzkwKLew54kZSsUTgeVvFJdIi/oRkdxtc=
+github.com/RedHatInsights/insights-results-aggregator-data v1.3.2/go.mod h1:E1UaB+IjJ/muxvMstVoqJrB82zVKNykjTtCiM3tMHoM=
+github.com/RedHatInsights/insights-results-types v1.2.0 h1:tFaGQE2h/4OIhf8sI/lRwJ/Fh0soO7a47de9x4irIJs=
+github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -24,7 +24,8 @@ import (
 
 	"github.com/RedHatInsights/insights-operator-utils/generators"
 	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
-	"github.com/RedHatInsights/insights-operator-utils/types"
+	utypes "github.com/RedHatInsights/insights-operator-utils/types"
+	types "github.com/RedHatInsights/insights-results-types"
 )
 
 const (
@@ -97,11 +98,11 @@ const (
 
 var (
 	// RuleCompositeIDs are in a `rule.module|ERROR_KEY` format
-	Rule1CompositeID, _ = generators.GenerateCompositeRuleID(types.RuleFQDN(Rule1ID), types.ErrorKey(ErrorKey1))
-	Rule2CompositeID, _ = generators.GenerateCompositeRuleID(types.RuleFQDN(Rule2ID), types.ErrorKey(ErrorKey2))
-	Rule3CompositeID, _ = generators.GenerateCompositeRuleID(types.RuleFQDN(Rule3ID), types.ErrorKey(ErrorKey3))
-	Rule4CompositeID, _ = generators.GenerateCompositeRuleID(types.RuleFQDN(Rule4ID), types.ErrorKey(ErrorKey4))
-	Rule5CompositeID, _ = generators.GenerateCompositeRuleID(types.RuleFQDN(Rule5ID), types.ErrorKey(ErrorKey5))
+	Rule1CompositeID, _ = generators.GenerateCompositeRuleID(utypes.RuleFQDN(Rule1ID), utypes.ErrorKey(ErrorKey1))
+	Rule2CompositeID, _ = generators.GenerateCompositeRuleID(utypes.RuleFQDN(Rule2ID), utypes.ErrorKey(ErrorKey2))
+	Rule3CompositeID, _ = generators.GenerateCompositeRuleID(utypes.RuleFQDN(Rule3ID), utypes.ErrorKey(ErrorKey3))
+	Rule4CompositeID, _ = generators.GenerateCompositeRuleID(utypes.RuleFQDN(Rule4ID), utypes.ErrorKey(ErrorKey4))
+	Rule5CompositeID, _ = generators.GenerateCompositeRuleID(utypes.RuleFQDN(Rule5ID), utypes.ErrorKey(ErrorKey5))
 	// Rule1 contains metainformation about rule with key NODE_INSTALLER_DEGRADED
 	Rule1 = types.Rule{
 		Module:     Rule1ID,


### PR DESCRIPTION
# Description

Use new package for types definition, but old one for some legacy declared functions. This commit should be merged and tagged to solve the craziness around the circular import problem between this repository and insights-operator-utils

## Type of change

- Refactor
- 
## Testing steps

Run the Travis configuration locally